### PR TITLE
To use custom workflows (Packer workflow)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       - PROXMOX_PASSWORD=${PROXMOX_PASSWORD}
       - PROXMOX_NODE=${PROXMOX_NODE}
       - PROXMOX_STORAGE=${PROXMOX_STORAGE}
+    command: >
+      server
+      --repo-config-allowed-overrides=workflow
     
     volumes:
       - atlantis-data:/atlantis-data


### PR DESCRIPTION
Atlantis server is not configured to allow repo-level workflow overrides (i.e., custom workflows defined in atlantis.yaml in your repo).

By default, Atlantis only allows certain keys (like automerge or apply_requirements) to be overridden in atlantis.yaml.
To use custom workflows (like your Packer workflow), we need to tell Atlantis it’s OK to override the workflow key.

Thus, this is to allow packer workflow to be able to execute. 